### PR TITLE
Add missing torch-mlir ops

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -4562,6 +4562,54 @@ def Torch_AtenRound_Op : Torch_Op<"aten.round_", [
   }];
 }
 
+def Torch_AtenRoundDecimalsOp : Torch_Op<"aten.round.decimals", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::round.decimals : (Tensor, int) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    Torch_IntType:$decimals
+  );
+  let results = (outs
+    AnyTorchOptionalTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenRoundDecimalsOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 2, 1);
+    }
+    void AtenRoundDecimalsOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 2, 1);
+    }
+  }];
+  let hasFolder = 1;
+}
+
+def Torch_AtenRound_DecimalsOp : Torch_Op<"aten.round_.decimals", [
+    IsTrailingUnderscoreInplaceVariant,
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::round_.decimals : (Tensor, int) -> (Tensor)`";
+  let arguments = (ins
+    Torch_NonValueTensorType:$self,
+    Torch_IntType:$decimals
+  );
+  let results = (outs
+    AnyTorchOptionalNonValueTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenRound_DecimalsOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 2, 1);
+    }
+    void AtenRound_DecimalsOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 2, 1);
+    }
+  }];
+}
+
 def Torch_AtenTruncOp : Torch_Op<"aten.trunc", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -10799,6 +10799,32 @@ def Torch_AtenAnyDimOp : Torch_Op<"aten.any.dim", [
   }];
 }
 
+def Torch_AtenAnyDimsOp : Torch_Op<"aten.any.dims", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::any.dims : (Tensor, int[]?, bool) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchOptionalListOfTorchIntType:$dim,
+    Torch_BoolType:$keepdim
+  );
+  let results = (outs
+    AnyTorchOptionalTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenAnyDimsOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 3, 1);
+    }
+    void AtenAnyDimsOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 3, 1);
+    }
+  }];
+  let hasFolder = 1;
+}
+
 def Torch_AtenArangeOp : Torch_Op<"aten.arange", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/lib/Conversion/TorchToStablehlo/Basic.cpp
+++ b/lib/Conversion/TorchToStablehlo/Basic.cpp
@@ -651,6 +651,62 @@ public:
 };
 } // namespace
 
+// AtenRoundDecimalsOp
+namespace {
+class ConvertAtenRoundDecimalsOp
+    : public OpConversionPattern<AtenRoundDecimalsOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenRoundDecimalsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value self = adaptor.getSelf();
+    auto selfTy = cast<TensorType>(self.getType());
+
+    if (!selfTy)
+      return op.emitError("only Tensor types supported in StableHLO");
+    if (!isa<mlir::FloatType>(selfTy.getElementType())) {
+      return op.emitError(
+          "only floating-point datatype legalization supported");
+    }
+    auto inType = cast<RankedTensorType>(
+        getTypeConverter()->convertType(op->getOperand(0).getType()));
+
+    auto outType = cast<RankedTensorType>(
+        getTypeConverter()->convertType(op->getResult(0).getType()));
+
+    int64_t decimals;
+    if (!matchPattern(op->getOperand(1), m_TorchConstantInt(&decimals))) {
+      return rewriter.notifyMatchFailure(
+          op, "non-constant decimal point is not supported.");
+    }
+    stablehlo::ConstantOp constantOp;
+
+    if (decimals) {
+      auto scalarVal = static_cast<float>(pow(10, decimals));
+      constantOp = rewriter.create<stablehlo::ConstantOp>(
+          op->getLoc(), inType,
+          DenseElementsAttr::get(inType, APFloat(scalarVal)));
+      self = rewriter.create<stablehlo::MulOp>(op.getLoc(), inType, self,
+                                               constantOp);
+    }
+
+    auto roundOp = rewriter.create<stablehlo::RoundNearestEvenOp>(
+        op.getLoc(), outType, self);
+
+    if (decimals) {
+      auto divOp = rewriter.create<stablehlo::DivOp>(op->getLoc(), outType,
+                                                     roundOp, constantOp);
+      rewriter.replaceOp(op, divOp);
+      return success();
+    }
+
+    rewriter.replaceOp(op, roundOp);
+    return success();
+  }
+};
+} // namespace
+
 // AtenTransposeIntOp
 namespace {
 class ConvertAtenTransposeIntOp
@@ -2147,6 +2203,8 @@ void mlir::torch::torch_to_stablehlo::populateBasicOpPatternsAndLegality(
     ConversionTarget &target, const TorchToStablehloOptions &options) {
   MLIRContext *context = patterns.getContext();
 
+  target.addIllegalOp<AtenRoundDecimalsOp>();
+  patterns.add<ConvertAtenRoundDecimalsOp>(typeConverter, context);
   target.addIllegalOp<AtenTransposeIntOp>();
   patterns.add<ConvertAtenTransposeIntOp>(typeConverter, context);
   target.addIllegalOp<RuntimeAssertOp>();

--- a/lib/Conversion/TorchToStablehlo/Reduction.cpp
+++ b/lib/Conversion/TorchToStablehlo/Reduction.cpp
@@ -117,7 +117,7 @@ static Value createInitialValueForReduceOp(Operation *op, Type elementTy,
                                                   constAttr);
   }
 
-  if (isa<AtenAnyOp, AtenAnyDimOp>(op)) {
+  if (isa<AtenAnyOp, AtenAnyDimOp, AtenAnyDimsOp>(op)) {
     auto constAttr =
         DenseElementsAttr::get(constType, {APInt(/*numBits=*/1, 0)});
     return rewriter.create<stablehlo::ConstantOp>(op->getLoc(), constType,
@@ -169,7 +169,7 @@ static Value createReduceOpWithSingleRegionOp(Operation *op, Value input,
     } else if (isa<AtenAllOp, AtenAllDimOp>(op)) {
       result = rewriter.create<stablehlo::AndOp>(
           op->getLoc(), blockArgumentTy, *firstArgument, *secondArgument);
-    } else if (isa<AtenAnyOp, AtenAnyDimOp>(op)) {
+    } else if (isa<AtenAnyOp, AtenAnyDimOp, AtenAnyDimsOp>(op)) {
       result = rewriter.create<stablehlo::OrOp>(
           op->getLoc(), blockArgumentTy, *firstArgument, *secondArgument);
     } else if (isa<AtenProdOp>(op)) {
@@ -610,6 +610,82 @@ public:
 };
 } // namespace
 
+// AtenAnyDimsOp
+namespace {
+template <>
+LogicalResult ConvertAtenReductionOp<AtenAnyDimsOp>::matchAndRewrite(
+    AtenAnyDimsOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  Value input = adaptor.getSelf();
+  auto inputTy = dyn_cast<RankedTensorType>(input.getType());
+  auto outTy =
+      dyn_cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
+  if (!inputTy) {
+    return rewriter.notifyMatchFailure(
+        op, "only Tensor types supported in StableHLO");
+  }
+  if (inputTy.getElementType() != outTy.getElementType()) {
+    // Use output element type as computation type.
+    auto dstElemTy = outTy.getElementType();
+    input =
+        rewriter.create<stablehlo::ConvertOp>(op->getLoc(), input, dstElemTy);
+    inputTy = dyn_cast<RankedTensorType>(input.getType());
+  }
+  auto inputElemTy = inputTy.getElementType();
+  if (!inputElemTy.isIntOrFloat()) {
+    return op.emitError(
+        "Only floating-point or integer datatype legalization supported");
+  }
+
+  SmallVector<int64_t> inputDims;
+  SmallVector<int64_t> dims;
+  if (!matchPattern(op.getDim(), m_TorchListOfConstantInts(inputDims))) {
+    return rewriter.notifyMatchFailure(
+        op, "non-const integer `dim` is not supported");
+  }
+  if (inputDims.size() == 0) {
+    rewriter.replaceOp(op, input);
+    return success();
+  }
+  for (auto d : inputDims) {
+    d = toPositiveDim(d, inputTy.getRank());
+    // Drop invalid dims
+    if (isValidDim(d, inputTy.getRank())) {
+      dims.push_back(d);
+    }
+  }
+  llvm::sort(dims.begin(), dims.end());
+
+  SmallVector<int64_t> reduceResultShape =
+      getReduceOutputShape(inputTy.getShape(), dims);
+
+  bool keepDim = false;
+  if (!matchPattern(op.getKeepdim(), m_TorchConstantBool(&keepDim))) {
+    return rewriter.notifyMatchFailure(op, "non-bool keepdim unsupported");
+  }
+
+  Value reduceResult = createReduceOpWithSingleRegionOp(
+      op, input,
+      RankedTensorType::get(reduceResultShape, outTy.getElementType()), dims,
+      rewriter);
+  if (!reduceResult) {
+    return op->emitError("createReduceOpWithSingleRegionOp return nullptr");
+  }
+
+  if (keepDim) {
+    auto outShapeInfo = hlo::getDimIndexOfTensor(rewriter, op, input);
+    if (failed(outShapeInfo)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to get dimension sizes of the input");
+    }
+    reduceResult = reshapeReduceResultWhenKeepDim(
+        rewriter, op->getLoc(), reduceResult, *outShapeInfo, outTy, dims);
+  }
+  rewriter.replaceOp(op, reduceResult);
+  return success();
+}
+} // namespace
+
 // AtenSumDimIntListOp
 namespace {
 template <>
@@ -865,6 +941,7 @@ void mlir::torch::torch_to_stablehlo::populateReductionOpPatternsAndLegality(
 #define INSERT_ATEN_REDUCTION_OP_PATTERN(AtenOp)                               \
   target.addIllegalOp<AtenOp>();                                               \
   patterns.add<ConvertAtenReductionOp<AtenOp>>(typeConverter, context, options)
+  INSERT_ATEN_REDUCTION_OP_PATTERN(AtenAnyDimsOp);
   INSERT_ATEN_REDUCTION_OP_PATTERN(AtenSumDimIntListOp);
   INSERT_ATEN_REDUCTION_OP_PATTERN(AtenFrobeniusNormDimOp);
   INSERT_ATEN_REDUCTION_OP_PATTERN(AtenLinalgVectorNormOp);

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -1121,6 +1121,22 @@ OpFoldResult AtenDimOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// AtenAnyDimsOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenAnyDimsOp::fold(FoldAdaptor adaptor) {
+  auto resultType = dyn_cast<ValueTensorType>(getResult().getType());
+  auto resultShape = resultType.toBuiltinTensor().getShape();
+  auto inputType = dyn_cast<ValueTensorType>(getOperand(0).getType());
+  auto inputShape = inputType.toBuiltinTensor().getShape();
+  if ((inputType.getDtype() == resultType.getDtype()) &&
+      (inputShape == resultShape)) {
+    return getSelf();
+  }
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
 // AtenLenTOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -2006,6 +2006,19 @@ OpFoldResult AtenRoundOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// AtenRoundDecimalsOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenRoundDecimalsOp::fold(FoldAdaptor adaptor) {
+  auto resultType = dyn_cast<ValueTensorType>(getType());
+  if (resultType && resultType.hasDtype() &&
+      isa<mlir::IntegerType>(resultType.getDtype())) {
+    return getSelf();
+  }
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
 // AtenTruncOp
 //===----------------------------------------------------------------------===//
 

--- a/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
+++ b/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
@@ -451,6 +451,9 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit_with_mutating_variants("aten::floor : (Tensor) -> (Tensor)", has_folder=True)
     emit_with_mutating_variants("aten::ceil : (Tensor) -> (Tensor)", has_folder=True)
     emit_with_mutating_variants("aten::round : (Tensor) -> (Tensor)", has_folder=True)
+    emit_with_mutating_variants(
+        "aten::round.decimals : (Tensor, int) -> (Tensor)", has_folder=True
+    )
     emit_with_mutating_variants("aten::trunc : (Tensor) -> (Tensor)", has_folder=True)
     emit("aten::special_expm1 : (Tensor) -> (Tensor)")
     emit_with_mutating_variants(

--- a/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
+++ b/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
@@ -834,6 +834,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::all.dim : (Tensor, int, bool) -> (Tensor)")
     emit("aten::any : (Tensor) -> (Tensor)")
     emit("aten::any.dim : (Tensor, int, bool) -> (Tensor)")
+    emit("aten::any.dims : (Tensor, int[]?, bool) -> (Tensor)", has_folder=True)
     emit("aten::arange : (Scalar, int?, int?, Device?, bool?) -> (Tensor)")
     emit(
         "aten::arange.start : (Scalar, Scalar, int?, int?, Device?, bool?) -> (Tensor)"


### PR DESCRIPTION
Following changes are added
1. [Torch] Add support aten.reduce.decimals op
2. [Stablehlo] Add Conversion for AtenRoundDecimalsOp
3. [Torch] Add support for aten.any.dims
4. [Stablehlo] Add Conversion for AtenAnyDimsOp
