### PR TITLE
[stablehlo] Add attribute ceil_mode to reduce_window op

### DIFF
--- a/lib/Conversion/TorchToStablehlo/Pooling.cpp
+++ b/lib/Conversion/TorchToStablehlo/Pooling.cpp
@@ -468,6 +468,7 @@ public:
     SmallVector<int64_t> stablehloDilation(inputRank, 1);
     SmallVector<int64_t> stablehloKernelSize(inputRank, 1);
     SmallVector<int64_t> stablehloPadding(inputRank * 2, 0);
+    SmallVector<int64_t> ceilModePadding(inputRank * 2, 0);
     std::copy(dilation.begin(), dilation.end(),
               stablehloDilation.begin() + inputRank - Dim);
     std::copy(stride.begin(), stride.end(),
@@ -520,6 +521,8 @@ public:
           const int64_t extraPadding = sizeDiff * stride[i];
           stablehloPadding[frontPadIdx] += extraPadding / 2;
           stablehloPadding[backPadIdx] += extraPadding - extraPadding / 2;
+          ceilModePadding[frontPadIdx] += extraPadding / 2;
+          ceilModePadding[backPadIdx] += extraPadding - extraPadding / 2;
         }
       }
     }
@@ -539,6 +542,19 @@ public:
         op->getLoc(), outTy, input, initVal, windowDimensions, windowStrides,
         baseDilations, windowDilations, pad);
 
+    // *** ADD THE 'ceil_mode' ATTRIBUTE ***
+    // The 'ceilMode' boolean variable was extracted from the PyTorch op
+    // earlier.
+    mlir::BoolAttr ceilModeAttr = rewriter.getBoolAttr(ceilMode);
+    reduceWindowOp->setAttr(llvm::StringRef("ceil_mode"), ceilModeAttr);
+    DenseIntElementsAttr ceilModePad = DenseIntElementsAttr::get(
+        RankedTensorType::get(
+            {static_cast<int64_t>(inputRank), static_cast<int64_t>(2)},
+            rewriter.getI64Type()),
+        stablehloPadding);
+    // Also add the 'ceil_mode_padding' attribute to the op to distinguish
+    // original padding from the extra padding added for ceil_mode.
+    reduceWindowOp->setAttr(llvm::StringRef("ceil_mode_padding"), ceilModePad);
     Block &block = reduceWindowOp.getBody().emplaceBlock();
 
     // Add bb argument

--- a/lib/Conversion/TorchToStablehlo/Pooling.cpp
+++ b/lib/Conversion/TorchToStablehlo/Pooling.cpp
@@ -551,7 +551,7 @@ public:
         RankedTensorType::get(
             {static_cast<int64_t>(inputRank), static_cast<int64_t>(2)},
             rewriter.getI64Type()),
-        stablehloPadding);
+        ceilModePadding);
     // Also add the 'ceil_mode_padding' attribute to the op to distinguish
     // original padding from the extra padding added for ceil_mode.
     reduceWindowOp->setAttr(llvm::StringRef("ceil_mode_padding"), ceilModePad);

--- a/test/Conversion/TorchToStablehlo/pooling.mlir
+++ b/test/Conversion/TorchToStablehlo/pooling.mlir
@@ -18,7 +18,7 @@
 // CHECK:           ^bb0(%[[VAL_8:.*]]: tensor<f32>, %[[VAL_9:.*]]: tensor<f32>):
 // CHECK:             %[[VAL_10:.*]] = stablehlo.maximum %[[VAL_8]], %[[VAL_9]] : tensor<f32>
 // CHECK:             stablehlo.return %[[VAL_10]] : tensor<f32>
-// CHECK:           }) : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
+// CHECK:           }) {ceil_mode = false, ceil_mode_padding = dense<0> : tensor<4x2xi64>} : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
 // CHECK:           %[[VAL_11:.*]] = torch_c.from_builtin_tensor %[[VAL_7]] : tensor<?x?x?x?xf32> -> !torch.vtensor<[?,?,?,?],f32>
 // CHECK:           return %[[VAL_11]] : !torch.vtensor<[?,?,?,?],f32>
 func.func @torch.aten.max_pool2d(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
@@ -51,7 +51,7 @@ func.func @torch.aten.max_pool2d(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch
 // CHECK:           ^bb0(%[[VAL_8:.*]]: tensor<f32>, %[[VAL_9:.*]]: tensor<f32>):
 // CHECK:             %[[VAL_10:.*]] = stablehlo.maximum %[[VAL_8]], %[[VAL_9]] : tensor<f32>
 // CHECK:             stablehlo.return %[[VAL_10]] : tensor<f32>
-// CHECK:           }) : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
+// CHECK{LITERAL}:  }) {ceil_mode = false, ceil_mode_padding = dense<[[0, 0], [0, 0], [2, 2], [1, 1]]> : tensor<4x2xi64>} : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
 // CHECK:           %[[VAL_7:.*]] = torch_c.from_builtin_tensor %[[VAL_6]] : tensor<?x?x?x?xf32> -> !torch.vtensor<[?,?,?,?],f32>
 // CHECK:           return %[[VAL_7]] : !torch.vtensor<[?,?,?,?],f32>
 func.func @torch.aten.max_pool2d$padding(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
@@ -84,7 +84,7 @@ func.func @torch.aten.max_pool2d$padding(%arg0: !torch.vtensor<[?,?,?,?],f32>) -
 // CHECK:           ^bb0(%[[VAL_8:.*]]: tensor<f32>, %[[VAL_9:.*]]: tensor<f32>):
 // CHECK:             %[[VAL_10:.*]] = stablehlo.maximum %[[VAL_8]], %[[VAL_9]] : tensor<f32>
 // CHECK:             stablehlo.return %[[VAL_10]] : tensor<f32>
-// CHECK:           }) : (tensor<1x256x56x56xf32>, tensor<f32>) -> tensor<1x256x27x27xf32>
+// CHECK:           }) {ceil_mode = false, ceil_mode_padding = dense<0> : tensor<4x2xi64>} : (tensor<1x256x56x56xf32>, tensor<f32>) -> tensor<1x256x27x27xf32>
 // CHECK:           %[[VAL_7:.*]] = torch_c.from_builtin_tensor %[[VAL_6]] : tensor<1x256x27x27xf32> -> !torch.vtensor<[1,256,27,27],f32>
 // CHECK:           return %[[VAL_7]] : !torch.vtensor<[1,256,27,27],f32>
 func.func @torch.aten.max_pool2d$ceiloff(%arg0: !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,27,27],f32> {
@@ -120,7 +120,7 @@ func.func @torch.aten.max_pool2d$ceiloff(%arg0: !torch.vtensor<[1,256,56,56],f32
 // CHECK:           ^bb0(%[[VAL_8:.*]]: tensor<f32>, %[[VAL_9:.*]]: tensor<f32>):
 // CHECK:             %[[VAL_10:.*]] = stablehlo.maximum %[[VAL_8]], %[[VAL_9]] : tensor<f32>
 // CHECK:             stablehlo.return %[[VAL_10]] : tensor<f32>
-// CHECK:           }) : (tensor<1x256x56x56xf32>, tensor<f32>) -> tensor<1x256x28x28xf32>
+// CHECK{LITERAL}:  }) {ceil_mode = true, ceil_mode_padding = dense<[[0, 0], [0, 0], [1, 1], [1, 1]]> : tensor<4x2xi64>} : (tensor<1x256x56x56xf32>, tensor<f32>) -> tensor<1x256x28x28xf32>
 // CHECK:           %[[VAL_7:.*]] = torch_c.from_builtin_tensor %[[VAL_6]] : tensor<1x256x28x28xf32> -> !torch.vtensor<[1,256,28,28],f32>
 // CHECK:           return %[[VAL_7]] : !torch.vtensor<[1,256,28,28],f32>
 func.func @torch.aten.max_pool2d$ceilon(%arg0: !torch.vtensor<[1,256,56,56],f32>) -> !torch.vtensor<[1,256,28,28],f32> {


### PR DESCRIPTION
In stablehlo, pool layer converts to reduce_window op, but it has no explicit field for `ceil_mode`.